### PR TITLE
Add files via upload

### DIFF
--- a/DataFeedback.java
+++ b/DataFeedback.java
@@ -1,5 +1,8 @@
 /****************************************/ 
 /*author:西村美玖 6/24更新 
+/* 		 佐野　渉 6/28更新
+ *       西村　美玖 6/29更新
+ */
 /*C6:フィードバック処理部所属 
 /*DataFeedback: 
 /*フィードバック処理部でのデータ処理を記述する
@@ -7,10 +10,11 @@
 
 package application;
 
+import java.util.ArrayList;
 import java.util.List;
 
-public class DataFeedback {
-	
+public class DataFeedback
+{
 	//-------------------------------------------- 
 	//List<Clothes> getList()
 	//服装データをとってくる処理
@@ -22,47 +26,64 @@ public class DataFeedback {
 	
 	
 	//-------------------------------------------- 
-	//double getWeight(int value)
-	//重みをラグランジュ補完から取得する
+	//List<double> getWeight(List<Integer> value)
+	//重みをラグランジュ補完により変換する
 	//--------------------------------------------
-		double[] getWeight(int value[])
+	List<Double> getWeight(List<Integer> value)
+	{
+		
+		List<Double> weightClothes = new ArrayList<Double>(); //ラグランジュ補完を適用した数値を格納する変数
+		
+		//ラグランジュ補完を呼び出す
+		for(int i = 0; i < value.size(); i++)
 		{
-			
-			double weightClothes[] = {};
-			//ラグランジュ補完を呼び出す
-			for(int i = 0; i < 5; i++)
-			{
-				weightClothes[i] = SceneContents.Lagrange(value[i], 1, 0.5, 6, 1, 11, 2);
-			}
-			
-			return weightClothes;
+			weightClothes.add(SceneContents.Lagrange(value.get(i)
+					, 1, Constant.WEIGHTRANGE[0], 6, 1, 11, Constant.WEIGHTRANGE[1]));
 		}
+		
+		return weightClothes;
+	}
 	
 	
 	//-------------------------------------------- 
-	//List<Clothes> calculateFeedback(double weightClothes[])
+	//List<Clothes> calculateFeedback(List<Double> weightClothes)
 	//重みとフィードバック数値をかけ合わせる
 	//--------------------------------------------
-		List<Clothes> calculateFeedback(double weightClothes[])
-		{
-			//ユーザ情報管理部から服装データリストをとってくる
-			List<Clothes> clothes = getList();
-			
-			for(int i = 0; i < 5; i++)
-			{
-				clothes.get(i).index = clothes.get(i).index * weightClothes[i];
-			}
-			return clothes;
-		}
+	List<Clothes> calculateFeedback(List<Double> weightClothes)
+	{
+		//ユーザ情報管理部から服装データリストをとってくる
+		List<Clothes> clothes = getList();
 		
+		//重みとフィードバック数値をかけ合わせ服装データリストに格納
+		for(int i = 0; i < clothes.size(); i++)
+		{
+			clothes.get(i).index = clothes.get(i).index * weightClothes.get(i);
+			clothes.set(i, clothes.get(i));
+		}
+		return clothes;
+	}
+	
 	//-------------------------------------------- 
 	//void writeUser(List<Clothes> clothes)
 	//ユーザ情報管理部に書き込みの命令を出す
 	//--------------------------------------------
 		
-		void writeUser(List<Clothes> clothes)
+	void writeUser(List<Clothes> clothes)
+	{
+		//書き込み命令
+		for(int i = 0; i < clothes.size(); ++i)
 		{
-			//書き込み命令
-			new UserData().clothesUpdate(clothes);
+			new UserData().clothesUpdate(clothes.get(i));
 		}
+	}
+	
+	//-------------------------------------------- 
+	//void flagReset()
+	//フィードバックフラグ(フィードバックを実施済みか)に関する処理
+	//--------------------------------------------
+	void flagReset()
+	{
+		//フィードバックフラグをfalseに戻す
+		new UserData().flagWrite(false);
+	}
 }

--- a/DataSettingClothing.java
+++ b/DataSettingClothing.java
@@ -1,5 +1,8 @@
 /****************************************/ 
-/*author:西村美玖 6/27更新 
+/*author:西村　美玖 6/27更新 
+/* 		 佐野　渉 6/29更新
+ * 　　　西村　美玖 6/30更新
+ */
 /*C7:服装情報設定処理部所属 
 /*DataSettingClothing: 
 /*服装設定情報処理部でのデータ処理を記述する
@@ -18,33 +21,43 @@ class DataSettingClothing
 	List<Clothes> getClothes()
 	{
 		List<Clothes> clothes;
-		//取得する
+		
+		//服装データを取得し服装データリストに格納
 		clothes = new UserData().clothesRead();
 		return clothes;
 	}
 	
 	
 	//-------------------------------------------- 
-	//void addClothes(List<Clothes> clothes)
+	//boolean addClothes(Clothes clothes)
 	//追加した服装情報をファイルに書き込む
 	//--------------------------------------------
-	void addClothes(Clothes clothes)
+	boolean addClothes(Clothes clothes)
 	{
-		//ユーザ情報処理部の書き込むメソッドを呼び出す
-		new UserData().clothesWrite(clothes);
+ 		if(matching(clothes.name).name == null)
+		{
+			//同じ名称の服装はない場合
+			//ユーザ情報処理部の書き込むメソッドを呼び出す
+			new UserData().clothesWrite(clothes);
+			return true;
+		} else {
+			//すでに同じ名称の服装がある場合
+			return false;
+		}
 	}
 	
 	
 	//-------------------------------------------- 
 	//Clothes matching(String clothesName)
-	//リストビューで選択された服装名称と
-	//削除した服装情報をファイルから削除する
+	//指定された名称の服装情報を全服装データから持ってくる
+	//clothesName:全服装データから取り出す服装名称
 	//--------------------------------------------
 	Clothes matching(String clothesName)
 	{
 		Clothes clothes = new Clothes();
 		List<Clothes> allClothes = getClothes();
-		//全ての服装データnameに会うデータを持ってくる
+		
+		//全ての服装データnameに合うデータを探し取得する
 		for(int i = 0; i < allClothes.size(); i++ )
 		{
 			if(clothesName.equals(allClothes.get(i).name))
@@ -63,5 +76,69 @@ class DataSettingClothing
 	void deleteClothes(Clothes clothes)
 	{
 		new UserData().clothesDelete(clothes);
+	}
+	
+	//-------------------------------------------- 
+	//int exceptionText(Clothes clothes)
+	//予期せぬ入力に対するエラーケースの分類を行う
+	//--------------------------------------------
+	int exceptionText(Clothes clothes)
+	{
+		//文字数カウント用
+		char[] chCount;
+		
+		//名称　文字数チェック
+		chCount = clothes.name.toCharArray();
+		if(chCount.length > Constant.LIMITWORDS)
+		{
+			return -1;
+		}
+		
+		//空欄チェック
+		if(chCount.length <= 0)
+		{
+			return -4;
+		}
+		
+		//服装分類　文字数チェック
+		chCount = clothes.kind.toCharArray();
+		if(chCount.length > Constant.LIMITWORDS)
+		{
+			return -2;
+		}
+		
+		//空欄チェック
+		if(chCount.length <= 0)
+		{
+			return -4;
+		}
+		
+		//部位分類　文字数チェック
+		chCount = clothes.part.toCharArray();
+		if(chCount.length > Constant.LIMITWORDS)
+		{
+			return -3;
+		}
+		
+		//服装指数　小数点チェック
+		chCount = Double.toString(clothes.index).toCharArray();
+		
+		//小数点になるまでインデックスを進める
+		int i;
+		for(i = 0; chCount[i] != '.'; ++i);
+		if((chCount.length - 3) > i)
+		{
+			//小数第二位よりも大きい場合
+			return -5;
+		}
+		
+		//空欄チェック
+		if(chCount.length <= 0)
+		{
+			return -4;
+		}
+		
+		//正常に実行された
+		return 0;
 	}
 }

--- a/DataSettingClothing.java
+++ b/DataSettingClothing.java
@@ -1,4 +1,3 @@
-
 /****************************************/ 
 /*author:西村美玖 6/27更新 
 /*C7:服装情報設定処理部所属 
@@ -9,11 +8,9 @@
 package application;
 
 import java.util.List;
-import java.util.ArrayList;
 
-public class DataSettingClothing
-{
-	new UserData().getCList() //インスタンスの生成
+class DataSettingClothing
+{	
 	//-------------------------------------------- 
 	//List<Clothes> getClothes()
 	//ユーザ情報管理部から全ての服装データを取ってくる
@@ -22,7 +19,7 @@ public class DataSettingClothing
 	{
 		List<Clothes> clothes;
 		//取得する
-		clothes = new UserData().getCList();
+		clothes = new UserData().clothesRead();
 		return clothes;
 	}
 	
@@ -34,7 +31,7 @@ public class DataSettingClothing
 	void addClothes(Clothes clothes)
 	{
 		//ユーザ情報処理部の書き込むメソッドを呼び出す
-		UserData().clothesWrite(clothes);
+		new UserData().clothesWrite(clothes);
 	}
 	
 	
@@ -45,14 +42,14 @@ public class DataSettingClothing
 	//--------------------------------------------
 	Clothes matching(String clothesName)
 	{
-		Clothes clothes;
+		Clothes clothes = new Clothes();
 		List<Clothes> allClothes = getClothes();
 		//全ての服装データnameに会うデータを持ってくる
 		for(int i = 0; i < allClothes.size(); i++ )
 		{
-			if(clothesName == allClothes[i].name)
+			if(clothesName.equals(allClothes.get(i).name))
 				{
-					clothes = allClothes[i];
+					clothes = allClothes.get(i);
 					break;
 				}
 		}
@@ -63,8 +60,8 @@ public class DataSettingClothing
 	//void deleteClothes(String clothes)
 	//削除した服装情報をファイルから削除する
 	//--------------------------------------------
-	void deleteClothes(String clothes)
+	void deleteClothes(Clothes clothes)
 	{
-		UserData().clothesDelete(clothes);
+		new UserData().clothesDelete(clothes);
 	}
 }

--- a/EventFeedback.java
+++ b/EventFeedback.java
@@ -1,47 +1,89 @@
 /**********************************************/
 /*author:西村　美玖 6/21更新
+/*		 佐野　渉 6/28更新
+ *       西村　美玖 6/29更新
+ */
 /*C6:フィードバック処理部所属
 /*EventFeedback:
 /*Feedbackモードでのイベント処理を記述したクラス
 /**********************************************/
 package application;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javafx.scene.control.Button;
+import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
+import javafx.scene.paint.Color;
 
 //イベント処理クラス
 class EventFeedback
 {
 	SceneFeedback feedback;
 	
-	double radioValue; //指数を格納する変数
+	Integer tempValue;
+	List<Integer> radioValue = new ArrayList<Integer>(); //服装指数を格納する変数"radioValue"
 	
-	int counter; //何回目かのカウント変数
+	int counter; //何回目かをカウントする変数"counter"
 	
+	//-------------------------------------------- 
+	//EventFeedback(SceneFeedback feedback)
+	//
+	//feedback:
+	//--------------------------------------------
 	EventFeedback(SceneFeedback feedback)
 	{
 		this.feedback = feedback;
 	}
 	
+	//-------------------------------------------- 
+	//void clickCancel(Button cancel)
+	//キャンセルを押した時に実行するイベント処理
+	//cancel:キャンセルボタン
+	//--------------------------------------------
 	void clickCancel(Button cancel)
 	{
 		cancel.setOnAction((ActionEvent) ->
-		{ feedback.assignSceneToStage("preference"); }); //キャンセルボタンを押したらW10画面へ遷移
+		{ 
+			new CreateAlert().confirm(Constant.CANCELMESSAGE); //キャンセルボタンを押したらキャンセルアラート表示
+			feedback.assignSceneToStage("home"); //ホーム画面へ遷移
+		}); 
 	}
 	
-	void clickRegister(Button register, int size)
+	//-------------------------------------------- 
+	//void clickRegister(Button register, int size, List<Label> labelList)
+	//登録を押した時に実行するイベント処理
+	//register:登録ボタン size:提案された服装の数 labelList:服装名称
+	//--------------------------------------------
+	void clickRegister(Button register, int size, List<Label> labelList)
 	{
 		
 		register.setOnAction((ActionEvent) ->
-		{
-			Clothes clothes = new Clothes();
-			
-			System.out.println(radioValue);
-			clothes.index = radioValue; //フィードバック指数はclothesリストの服装指数に格納?ラグランジュ関数に渡す別の変数?
-			counter++;
-			if(counter == size) 
+		{	
+			if(tempValue == null) //ラジオボタンが選択されていないときはエラー表示
 			{
-				new CreateAlert().complete("登録が完了しました。"); //登録完了アラート画面表示
+				new CreateAlert().failure(Constant.EMPTYRADIOERROR);
+				return;
+			} else {
+				counter++; //カウンターを1進める
+				radioValue.add(tempValue);	//ラジオボタンの値を保存
+			}
+				
+			if(counter == size) //提案された服装分評価した場合
+			{
+				labelList.get(counter - 2).setTextFill(Color.BLACK);
+				DataFeedback df = new DataFeedback();
+				df.writeUser(df.calculateFeedback(df.getWeight(radioValue)));
+				new CreateAlert().complete(Constant.REGISTERMESSAGE); //登録完了アラート画面表示
+				df.flagReset();
+				feedback.assignSceneToStage("home");
+			} else {
+				labelList.get(counter - 1).setTextFill(Color.RED);
+				if(1 < counter)
+				{
+					labelList.get(counter - 2).setTextFill(Color.BLACK);
+				}
 			}
 			
 		});
@@ -49,11 +91,16 @@ class EventFeedback
 		
 	}
 	
+	//-------------------------------------------- 
+	//void clickRadio(RadioButton rb)
+	//ラジオボタンが選択された時に実行するイベント処理
+	//rb:ラジオボタン
+	//--------------------------------------------
 	void clickRadio(RadioButton rb)
 	{
 		rb.setOnAction((ActionEvent) ->
 		{
-			radioValue = Double.parseDouble(rb.getText());
+			tempValue = Integer.parseInt(rb.getText()); //選択されているラジオボタンの値をtempValueに保管		
 		});
 	}
 }

--- a/EventSettingClothing.java
+++ b/EventSettingClothing.java
@@ -15,23 +15,25 @@ import javafx.scene.control.TextField;
 
 public class EventSettingClothing 
 {
-	SceneSettingClothing settingclothing;
+	SceneSettingClothing settingClothing;
 	
 	EventSettingClothing(SceneSettingClothing settingclothing)
 	{
-		this.settingclothing = settingclothing;
+		this.settingClothing = settingclothing;
 	}
 	
 	void clickCancel(Button cancel)
 	{
 		cancel.setOnAction((ActionEvent) ->
-		{settingclothing.assignSceneToStage("preference");}); //キャンセルボタンを押したらW10画面へ遷移
+		{ settingClothing.assignSceneToStage("preference"); }); //キャンセルボタンを押したらW10画面へ遷移
 	}
 	
 	void clickRegister1(Button register, List<TextField> tf)
 	{
 		register.setOnAction((ActionEvent) -> 
 		{
+			//
+			try {
 			//String clothingName;
 			//String clothingClass;
 			//String bodyClass;
@@ -53,9 +55,12 @@ public class EventSettingClothing
 			System.out.println(clothes.part);
 			System.out.println(clothes.index);
 			
-			new CreateAlert().complete("登録が完了しました。"); //登録完了アラート画面表示
-			
-			
+			//登録完了アラート画面表示
+			new DataSettingClothing().addClothes(clothes);
+			new CreateAlert().complete(Constant.REGISTERMESSAGE);
+		}catch(Exception e) {
+			new CreateAlert().failure("ERROR"); //テキストフィールドに予期せぬ入力がされたらエラーアラート画面表示
+		}
 		}); 
 	}
 	
@@ -63,24 +68,45 @@ public class EventSettingClothing
 	{
 		register.setOnAction((ActionEvent) -> 
 		{
+			//
+			try {
 			String deleteClothing;
 			String name;
 			deleteClothing = lv.getSelectionModel().getSelectedItem();
 			
 			//名前を取り出す
 			name = deleteClothing;
-			//データ処理部を呼び出す,消すアイテムをclotheにいれる
+			//データ処理部を呼び出す,消すアイテムをclothesにいれる
 			Clothes clothes = new DataSettingClothing().matching(name);
-			for(int i = 0; i < ol.size(); i++)
-			{
-				if(ol.get(i).equals(clothes.name)) ol.remove(i);
-			}
+			//確認用
+			
+			
+			
+			
 			
 			//確認用
 			System.out.println(deleteClothing);
 			
-			new CreateAlert().complete("削除が完了しました。"); //登録完了アラート画面表示
-			
+			boolean check = new CreateAlert().confirm(Constant.DELETEQUESTION); //削除確認アラート画面表示
+			if(check == true)
+			{
+				System.out.println("true");
+				for(int i = 0; i < ol.size(); i++)
+				{
+					if(ol.get(i).equals(clothes.name))
+						{
+							ol.remove(i);
+						}
+					
+				}
+				//System.out.println(clothes);
+				new DataSettingClothing().deleteClothes(clothes);
+				new CreateAlert().complete(Constant.DELETECOMPLETE); //削除完了アラート画面表示
+				
+			}
+			}catch(Exception e) {
+				new CreateAlert().failure("ERROR");
+			}
 			
 		}); 
 	}
@@ -88,14 +114,13 @@ public class EventSettingClothing
 	void clickDelete(Button delete)
 	{
 		delete.setOnAction((ActionEvent) ->
-		{
-			settingclothing.assignSceneToStage("delete");}); //削除ボタンを押したらW9画面へ移動
+		{settingClothing.assignSceneToStage("delete");}); //削除ボタンを押したらW9画面へ移動
 	}
 	
 	void clickAddition(Button add)
 	{
 		add.setOnAction((ActionEvent) ->
-		{settingclothing.assignSceneToStage("addition");}); //追加ボタンを押したらW9画面へ移動
+		{settingClothing.assignSceneToStage("addition");}); //追加ボタンを押したらW9画面へ移動
 	}
 }
 

--- a/EventSettingClothing.java
+++ b/EventSettingClothing.java
@@ -1,5 +1,6 @@
 /**********************************************/
 /*author:西村　美玖 6/21更新
+/		 佐野　渉 6/29更新
 /*C7:服装設定処理部所属
 /*EventSettingClothing:
 /*服装設定モードのイベント処理を記述したクラス
@@ -17,146 +18,160 @@ public class EventSettingClothing
 {
 	SceneSettingClothing settingClothing;
 	
+	//-------------------------------------------- 
+	//EventSettingClothing(SceneSettingClothing settingclothing)
+	//
+	//settingclothing:
+	//--------------------------------------------
 	EventSettingClothing(SceneSettingClothing settingclothing)
 	{
 		this.settingClothing = settingclothing;
 	}
 	
+	//-------------------------------------------- 
+	//void clickCancel(Button cancel)
+	//キャンセルを押した時に実行するイベント処理
+	//cancel:キャンセルボタン
+	//--------------------------------------------
 	void clickCancel(Button cancel)
 	{
 		cancel.setOnAction((ActionEvent) ->
 		{ settingClothing.assignSceneToStage("preference"); }); //キャンセルボタンを押したらW10画面へ遷移
 	}
 	
+	//-------------------------------------------- 
+	//void clickRegister1(Button register, List<TextField> tf)
+	//服装追加モードで登録を押した時に実行するイベント処理
+	//register:登録ボタン tf:4つのテキストフィールド
+	//--------------------------------------------
 	void clickRegister1(Button register, List<TextField> tf)
 	{
 		register.setOnAction((ActionEvent) -> 
 		{
-			//
-			try {
-			//String clothingName;
-			//String clothingClass;
-			//String bodyClass;
-			//double clothingValue;
-			
-			Clothes clothes = new Clothes();
-			
-			clothes.name = tf.get(0).getText();
-			clothes.kind = tf.get(1).getText();
-			clothes.part = tf.get(2).getText();
-			clothes.index = Double.parseDouble(tf.get(3).getText());
-			
-			//データ処理部の書き込みメソッドを呼び出す
-			//new DataSettingClothing().addClothes(clothes);
-			
-			//確認用
-			System.out.println(clothes.name);
-			System.out.println(clothes.kind);
-			System.out.println(clothes.part);
-			System.out.println(clothes.index);
-			
-			//登録完了アラート画面表示
-			new DataSettingClothing().addClothes(clothes);
-			new CreateAlert().complete(Constant.REGISTERMESSAGE);
-		}catch(Exception e) {
-			new CreateAlert().failure("ERROR"); //テキストフィールドに予期せぬ入力がされたらエラーアラート画面表示
-		}
+			try
+			{
+				Clothes clothes = new Clothes();
+				
+				//テキストボックスの値を格納
+				clothes.name = tf.get(0).getText();
+				clothes.kind = tf.get(1).getText();
+				clothes.part = tf.get(2).getText();
+				clothes.index = Double.parseDouble(tf.get(3).getText());
+				
+				//テキストボックスエラー処理
+				switch(new DataSettingClothing().exceptionText(clothes))
+				{
+				case -1 :
+					new CreateAlert().failure(Constant.NAMEERROR);
+					return;
+				case -2 :
+					new CreateAlert().failure(Constant.CLOTHESERROR);
+					return;
+				case -3 :
+					new CreateAlert().failure(Constant.PARTERROR);
+					return;
+				case -4 :
+					new CreateAlert().failure(Constant.EMPTYERROR);
+					return;
+				case -5 :
+					new CreateAlert().failure(Constant.INDEXERROR);
+					return;
+				}
+				
+				//登録完了アラート画面表示
+				if(new DataSettingClothing().addClothes(clothes))
+				{
+					//リストに服装を追加
+					settingClothing.getOList().add(clothes.name);
+					
+					//服装追加成功
+					new CreateAlert().complete(Constant.REGISTERMESSAGE);
+					
+					//テキストフィールドをリセット
+					settingClothing.resetText();
+				} else {
+					//服装追加失敗
+					new CreateAlert().failure(Constant.ADDCLOTHESERROR);
+				}
+			} catch(NumberFormatException e) {
+				//服装指数が無効な数字であった場合
+				new CreateAlert().failure(Constant.INDEXERROR);
+			} catch(Exception e) {
+				//それ以外の場合
+				new CreateAlert().failure(Constant.UNKNOWNERROR);
+				e.printStackTrace();
+			}
 		}); 
 	}
 	
-	void clickRegister2(Button register, ObservableList<String> ol, ListView<String> lv)
+	//-------------------------------------------- 
+	//void clickRegister2(Button register)
+	//服装削除モードで登録を押した時に実行するイベント処理
+	//register:登録ボタン
+	//--------------------------------------------
+	void clickRegister2(Button register)
 	{
 		register.setOnAction((ActionEvent) -> 
 		{
-			//
-			try {
-			String deleteClothing;
-			String name;
-			deleteClothing = lv.getSelectionModel().getSelectedItem();
-			
-			//名前を取り出す
-			name = deleteClothing;
-			//データ処理部を呼び出す,消すアイテムをclothesにいれる
-			Clothes clothes = new DataSettingClothing().matching(name);
-			//確認用
-			
-			
-			
-			
-			
-			//確認用
-			System.out.println(deleteClothing);
-			
-			boolean check = new CreateAlert().confirm(Constant.DELETEQUESTION); //削除確認アラート画面表示
-			if(check == true)
+			try
 			{
-				System.out.println("true");
-				for(int i = 0; i < ol.size(); i++)
-				{
-					if(ol.get(i).equals(clothes.name))
-						{
-							ol.remove(i);
-						}
-					
-				}
-				//System.out.println(clothes);
-				new DataSettingClothing().deleteClothes(clothes);
-				new CreateAlert().complete(Constant.DELETECOMPLETE); //削除完了アラート画面表示
+				ObservableList<String> ol = settingClothing.getOList();
+				ListView<String> lv = settingClothing.getVList();
+				String deleteClothing;
+				String name;
 				
+				//選択されたリストビューの項目名を格納
+				deleteClothing = lv.getSelectionModel().getSelectedItem();
+				
+				//名前を取り出す
+				name = deleteClothing;
+				
+				//データ処理部を呼び出す,消すアイテムをclothesにいれる
+				Clothes clothes = new DataSettingClothing().matching(name);
+				
+				//削除確認アラート画面表示
+				boolean check = new CreateAlert().confirm(Constant.DELETEQUESTION);
+				if(check == true)
+				{
+					for(int i = 0; i < ol.size(); i++)
+					{
+						if(ol.get(i).equals(clothes.name)) ol.remove(i); //リストビューから削除
+					}
+					new DataSettingClothing().deleteClothes(clothes);
+					new CreateAlert().complete(Constant.DELETECOMPLETE); //削除完了アラート表示
+				}
+			} catch(Exception e) { //例外処理
+				new CreateAlert().failure(Constant.UNKNOWNERROR); //エラーアラート表示
+				e.printStackTrace();
 			}
-			}catch(Exception e) {
-				new CreateAlert().failure("ERROR");
-			}
-			
 		}); 
 	}
 	
+	//-------------------------------------------- 
+	//void clickDelete(Button delete)
+	//削除ボタンが選択された時に実行するイベント処理(モード変更)
+	//delete:削除ボタン
+	//--------------------------------------------
 	void clickDelete(Button delete)
 	{
 		delete.setOnAction((ActionEvent) ->
-		{settingClothing.assignSceneToStage("delete");}); //削除ボタンを押したらW9画面へ移動
+		{
+			//削除ボタンを押したらW9削除モード画面へ移動
+			settingClothing.assignSceneToStage("delete");
+		});
 	}
 	
+	//-------------------------------------------- 
+	//void clickAddition(Button add)
+	//追加ボタンが選択された時に実行するイベント処理(モード変更)
+	//add:登録ボタン
+	//--------------------------------------------
 	void clickAddition(Button add)
 	{
 		add.setOnAction((ActionEvent) ->
-		{settingClothing.assignSceneToStage("addition");}); //追加ボタンを押したらW9画面へ移動
+		{
+			//追加ボタンを押したらW8追加モード画面へ移動
+			settingClothing.assignSceneToStage("addition");
+		});
 	}
 }
-
-/*public class EventClothingList
-{
-	SceneClothingList clothinglist;
-	
-	EventClothingList(SceneInputClothing clothinglist)
-	{
-		this.clothinglist = clothinglist;
-	}
-	
-	void clickRegister(Button register, ListView<String> lv)
-	{
-		register.setOnAction((ActionEvent) -> 
-		{
-			String deleteClothing;
-			deleteClothing = lv.getSelectionModel().getSelectedItem();
-			
-			//確認用
-			System.out.println(deleteClothing);
-			
-			boolean check = new CreateAlert().confirm("削除が完了しました。"); //登録完了アラート画面表示
-			if(check == true)
-			{
-				System.out.println("true");
-			}else{
-				System.out.println("false");
-			}
-			
-		}); 
-	}
-	
-	void clickAdd(Button add)
-	{
-		add.setOnAction((ActionEvent) ->
-		{clothinglist.assignSceneToStage("add");}); //追加ボタンを押したらW9画面へ移動
-	}
-}*/

--- a/SceneFeedback.java
+++ b/SceneFeedback.java
@@ -1,5 +1,8 @@
 /**********************************************/
 /*author:西村　美玖 6/21更新
+/* 		 佐野　渉 6/28更新
+ *       西村　美玖 6/29更新
+ */
 /*C6:フィードバック処理部所属
 /*SceneFeedback:
 /*Feedbackモードの際に表示する画面を作成したクラス
@@ -9,6 +12,7 @@ package application;
 import java.util.ArrayList;
 import java.util.List;
 
+import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
@@ -18,111 +22,163 @@ import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
+import javafx.scene.text.Font;
 import javafx.stage.Stage;
 
 class SceneFeedback extends SceneMain 
 {
-	Scene scene;
+	Scene scene; //フィールド
 	
+	//-------------------------------------------- 
+	//SceneProposal(Stage stage)
+	//スーパークラスからステージ情報を受け取る
+	//stage:シーンの割り当てられたステージ
+	//--------------------------------------------
 	SceneFeedback(Stage stage)
 	{
 		super(stage);
 	}
 	
+	//-------------------------------------------- 
+	//void createFeedback()
+	//フィードバックモードでの画面配置を行う
+	//引数なし
+	//--------------------------------------------
 	void createFeedback()
 	{
 		BorderPane bp = new BorderPane();
+		
+		ToggleGroup tg = new ToggleGroup(); //rbの中で選択が1つのみになる処理のための変数tg
+		
 		//イベントオブジェクトの作成
 		EventFeedback event = new EventFeedback(this);
 		
-		/*List<RadioButton> rb = new ArrayList<RadioButton>()
+		//ラジオボタンを11個作成する処理
+		List<RadioButton> rb = new ArrayList<RadioButton>()
 		{
 			{
-				for(int i=1; i<=11; i++)
+				for(int i = 1; i <= 11; i++)
 				{
 					add(new RadioButton(Integer.toString(i)));
 				}
 			}
 		};
 		
-		ToggleGroup tg = new ToggleGroup(); //rbの中で選択が1つのみになる処理
-		for(int i=0; i<rb.size(); ++i) {
+		//rbの中で選択が1つのみになる処理
+		for(int i = 0; i < rb.size(); ++i) 
+		{
 			rb.get(i).setToggleGroup(tg);
 			//rb.get(i).setOnAction(new FeedbackEventHandler());
 		}
 		
-		HBox hb_rb = new HBox(); //rbを水平に並べたかたまり"hb_rb"
-		hb_rb.getChildren().addAll(rb);
-		
+		//ラベル作成処理
+		Label title = new Label("提案された服装を段階的に評価します"); //上部メッセージラベル"title"
+		Label day = new Label("〇月〇日の評価"); //日付表示ラベル"day"
 		
 		Label cold = new Label("←寒い"); //寒いラベル"cold"
 		Label appropriate = new Label("適切"); //適切ラベル"appropriate"
 		Label hot = new Label("暑い→"); //暑いラベル"hot"
 		
-		HBox hb_thermometer = new HBox(); //cold,appropraite, hotの3つのラベルを水平に並べたかたまり"hb_thermometer"
-		hb_thermometer.getChildren().addAll(cold, appropriate, hot);
-		hb_thermometer.setSpacing(100);
+		Button register = new Button("登録"); //登録ボタン"register"
+		Button cancel = new Button("キャンセル"); //キャンセルボタン"cancel"
 		
+		day.setTranslateX(-100);
 		
-		Label day = new Label("\n\n\n\n〇月〇日の評価"); //日付表示ラベル"day"
-		
+		//ラベルのフォント設定処理
+		title.setFont(Font.font(Constant.FONTFAMILY,Constant.FONTWEIGHT,20));
+		day.setFont(Font.font(Constant.FONTFAMILY,Constant.FONTWEIGHT,15));
+		register.setFont(Font.font(Constant.FONTFAMILY,Constant.FONTWEIGHT,20));
+		cancel.setFont(Font.font(Constant.FONTFAMILY,Constant.FONTWEIGHT,20));
+		cold.setFont(Font.font(Constant.FONTFAMILY,Constant.FONTWEIGHT,20));
+		appropriate.setFont(Font.font(Constant.FONTFAMILY,Constant.FONTWEIGHT,20));
+		hot.setFont(Font.font(Constant.FONTFAMILY,Constant.FONTWEIGHT,20));
 		
 		//ラベル作成
-		List<Clothes> clothes = new DataFeedback().getList();
+		//List<Clothes> clothes = new DataFeedback().getList();
+		
+		//ダミーデータここから
+		List<Clothes> clothes = new ArrayList<Clothes>();
+		clothes.add(new Clothes(1, "上着A", "上着", "上半身", 12.3));
+		clothes.add(new Clothes(1, "上着A", "上着", "上半身", 12.3));
+		clothes.add(new Clothes(1, "上着A", "上着", "上半身", 12.3));
+		clothes.add(new Clothes(1, "上着A", "上着", "上半身", 12.3));
+		clothes.add(new Clothes(1, "上着A", "上着", "上半身", 12.3));
+		new UserData().createCList(clothes);
+		//ダミーデータここまで　
+		
+		//Labelに提案された服装名称を追加する処理
 		List<Label> label = new ArrayList<Label>()
+		{
 			{
+				for(int i = 0; i < clothes.size(); i++)
 				{
-					for(int i = 0; i < clothes.size(); i++)
-					{
-						add(new Label(clothes.get(i).name));  //Labelに服装名称を追加する
-					}
+					add(new Label("・" + clothes.get(i).name));  
+					
 				}
-			};
+			}
+		};
 		
-		//Label hat = new Label("帽子"); //帽子ラベル"hat"
-		//Label hand = new Label("手袋"); //手袋ラベル"hand"
-		//Label outerwear = new Label("上着"); //上着ラベル"outerwear"
-		//Label pants = new Label("ズボン"); //ズボンラベル"pants"
-		//Label socks = new Label("靴下"); //靴下ラベル"socks"
+		//ラベルのフォント設定処理
+		for(int i = 0; i < label.size(); ++i)
+		{
+			label.get(i).setFont(Font.font(Constant.FONTFAMILY,Constant.FONTWEIGHT,18));
+		}
 		
-		VBox vb_clothing = new VBox(); //帽子、手袋、上着、ズボン、靴下を垂直に塊にしたグループ"clothing"
-		vb_clothing.getChildren().addAll(label);
-		vb_clothing.setSpacing(20);
+		//配置コントロール処理
+		VBox vbTop = new VBox(); //"subTitle"と"title"を上部で垂直に並べた塊"vbTop"
+		vbTop.setAlignment(Pos.CENTER);
+		vbTop.setSpacing(10);
+		vbTop.getChildren().addAll(SceneContents.subTitle("フィードバック"), title);
+			
+		VBox vbClothing = new VBox(); //服装名称ラベル"label"を垂直に並べた塊"vbClothing"
+		vbClothing.getChildren().addAll(label);
+		vbClothing.setSpacing(10);
+		vbClothing.setAlignment(Pos.CENTER);
+		vbClothing.setTranslateX(-100);
 		
+		HBox hbRb = new HBox(); //rbを水平に並べたかたまり"hbRb"
+		hbRb.getChildren().addAll(rb);
+		hbRb.setAlignment(Pos.CENTER);
 		
-		VBox vb_center = new VBox(); //日付、服装、服装指数、メータを垂直に1つにまとめた真ん中に配置するグループ
-		vb_center.getChildren().addAll(day, vb_clothing, hb_rb, hb_thermometer);
-		vb_center.setSpacing(20);
+		HBox hbThermometer = new HBox(); //cold,appropraite, hotのラベルを水平に並べた塊"hbThermometer"
+		hbThermometer.getChildren().addAll(cold, appropriate, hot);
+		hbThermometer.setSpacing(100);	
+		hbThermometer.setAlignment(Pos.CENTER);
 		
+		VBox vbCenter = new VBox(); //"day", "vbClothing" "hbRb", "hbThermometer"を中央で垂直に並べた塊"vbCenter"
+		vbCenter.setAlignment(Pos.CENTER);
+		vbCenter.getChildren().addAll(day, vbClothing, hbRb, hbThermometer);
+		vbCenter.setSpacing(20);
 		
+		HBox hbButton = new HBox(); //registerとcancelを水平に並べた塊"hbButton"
+		hbButton.setAlignment(Pos.CENTER);
+		hbButton.getChildren().addAll(cancel, register);
+		hbButton.setPadding(new Insets(9, 9, 9, 9));
+		hbButton.setSpacing(171); 
 		
-		Button register = new Button("登録"); //登録ボタン"register"
-		register.setPrefSize(100, 20); //ボタンサイズ
-		Button cancel = new Button("キャンセル"); //キャンセルボタン"cancel"
-		cancel.setPrefSize(100, 20); //ボタンサイズ
+		//ペイン割り当て処理
+		bp.setTop(vbTop);
+		bp.setCenter(vbCenter); 
+		bp.setBottom(hbButton);
 		
-		HBox hb_button = new HBox(); //registerとcancelを水平に並べたかたまり"hb_button"
-		hb_button.getChildren().addAll(cancel, register);
-		hb_button.setSpacing(100); //cancelとregisterの距離
-		
-		vb_center.setAlignment(Pos.CENTER);
-		hb_button.setAlignment(Pos.CENTER);
-		
-		bp.setTop(vb_center); //ペイン割り当て
-		bp.setBottom(hb_button);
-		
-		//イベント割り当て
-		int size = 5; //ラベルの数だけ
-		event.clickRegister(register, size+1);
+		//イベント割り当て処理
+		int size = 5; //ラベルの数を示す"size"
+		event.clickRegister(register, (size + 1), label);
 		for(int i = 0; i < rb.size(); i++ )
 		{
 			event.clickRadio(rb.get(i));
-		}*/
+		}
+		event.clickCancel(cancel);
 		
-		//シーンの作成
+		//シーンの作成処理
 		this.scene = new Scene(bp, Constant.WIDTH, Constant.HEIGHT);
 	}
-	
+	//-------------------------------------------- 
+	//void getScene()
+	//シーン情報を返すメソッド
+	//画面遷移に利用する
+	//scene:シーンのレイアウト情報
+	//--------------------------------------------
 	Scene getScene() 
 	{
 		return this.scene;

--- a/SceneSettingClothing.java
+++ b/SceneSettingClothing.java
@@ -6,11 +6,10 @@
 /**********************************************/
 package application;
 
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 
 import javafx.collections.FXCollections;
-import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -19,7 +18,6 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.control.TextField;
-import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
@@ -174,17 +172,22 @@ public class SceneSettingClothing extends SceneMain {
 		
 		ObservableList<String> ol =
 				FXCollections.observableArrayList();
+		//すべての服装データをDBからとってくる
+		List<Clothes> clothes = new DataSettingClothing().getClothes();
 		//for(int i = 0; i < clothes.size(); i++)
 		//{
 		//	ol.add(clothes.get(i).name);  //Labelに服装名称を追加する
 		//}
-		
-		ol.add("上着A");
+		for(int i = 0; i < clothes.size(); ++i)
+		{
+			ol.add(clothes.get(i).name);
+		}
 	
 		lv.setItems(ol);	
 		
 		event.clickCancel(button.get(0));
 		event.clickAddition(addition);
+		event.clickRegister2(button.get(1),  ol,  lv);
 		
 		//ペイン割り当て
 		bp.setTop(vb_top);

--- a/SceneSettingClothing.java
+++ b/SceneSettingClothing.java
@@ -1,5 +1,8 @@
 /**********************************************/
 /*author:西村　美玖 6/21更新
+/*		 佐野　渉 6/28更新
+ *       西村　美玖 6/29更新
+ */
 /*C7:服装設定処理部所属
 /*SceneSettingClothing:
 /*服装設定モードの際に表示する画面を作成したクラス
@@ -24,22 +27,42 @@ import javafx.scene.layout.VBox;
 import javafx.scene.text.Font;
 import javafx.stage.Stage;
 
-public class SceneSettingClothing extends SceneMain {
+public class SceneSettingClothing extends SceneMain 
+{
+	Scene scene; //フィールド
 	
-	Scene scene;
+	static ObservableList<String> ol; //閲覧可能リスト"ol"
 	
+	static ListView<String> lv; //リストビュー"lv"
+	
+	List<TextField> tf; //テキストフィールド"tf"
+	
+	//-------------------------------------------- 
+	//SceneProposal(Stage stage)
+	//スーパークラスからステージ情報を受け取る
+	//stage:シーンの割り当てられたステージ
+	//--------------------------------------------
 	SceneSettingClothing(Stage stage)
 	{
 		super(stage);
 	}
 
-	void createAddition() {
+	//-------------------------------------------- 
+	//void createAddition()
+	//服装追加モードでの画面配置を行う
+	//引数なし
+	//--------------------------------------------
+	void createAddition() 
+	{
 		
-		//オブジェクト作成
 		BorderPane bp = new BorderPane();
-		EventSettingClothing event = new EventSettingClothing(this);
-		Label title = new Label("追加する服装の情報を入力してください");
 		
+		//イベントオブジェクトの作成
+		EventSettingClothing event = new EventSettingClothing(this);
+		
+		Label title = new Label("追加する服装の情報を入力してください"); //上部メッセージラベル"title"
+		
+		//名称、服装分類、部位分類、服装指数ラベルリスト"lb"の作成
 		List<Label> lb = new ArrayList<Label>()
 		{
 			{
@@ -50,7 +73,9 @@ public class SceneSettingClothing extends SceneMain {
 			}
 		};
 		
-		Button delete = new Button("削除");
+		Button delete = new Button("削除"); //削除ボタン"delete"
+		
+		//キャンセル、登録ボタンリスト"button"の作成
 		List<Button> button = new ArrayList<Button>()
 		{
 			{
@@ -59,7 +84,8 @@ public class SceneSettingClothing extends SceneMain {
 			}
 		};
 		
-		List<TextField> tf = new ArrayList<TextField>()
+		//4つのテキストフィールド"tf"の作成
+		tf = new ArrayList<TextField>()
 		{
 			{
 				add(new TextField());
@@ -112,29 +138,41 @@ public class SceneSettingClothing extends SceneMain {
 		hb_bottom.setSpacing(171);
 		hb_bottom.setAlignment(Pos.CENTER);
 		
-		//ペイン割り当て
+		//ペイン割り当て処理
 		bp.setTop(vb_top);
 		bp.setRight(delete);
 		bp.setCenter(vb_center);
 		bp.setBottom(hb_bottom);
 		
-		//イベント処理系
+		//イベント処理
 		event.clickDelete(delete);
 		event.clickCancel(button.get(0));
 		event.clickRegister1(button.get(1), tf);
 		
+		//シーンの作成処理
 		this.scene = new Scene(bp, Constant.WIDTH, Constant.HEIGHT);
 	 }
 	 
+	//-------------------------------------------- 
+	//void createDelete()
+	//服装削除モードでの画面配置を行う
+	//引数なし
+	//--------------------------------------------
 	 void createDelete()
 	 {
  		//オブジェクト作成
 		Stage subStage = new Stage();
 		BorderPane bp = new BorderPane();
+		
+		//イベントオブジェクトの作成
  		EventSettingClothing event = new EventSettingClothing(this);
- 		ListView<String> lv = new ListView<String>();
-		Button addition = new Button("追加");
-		Label title = new Label("削除する服装の情報を入力してください");
+ 		
+		Button addition = new Button("追加"); //追加ボタン"addition"
+		Label title = new Label("削除する服装の情報を入力してください"); //上部メッセージラベル"title"
+		
+		lv = new ListView<String>();
+		
+		//キャンセル、登録ボタンリスト"button"の作成
 		List<Button> button = new ArrayList<Button>()
 		{
 			{
@@ -160,7 +198,7 @@ public class SceneSettingClothing extends SceneMain {
 		addition.setTranslateX(-20);
 		addition.setTranslateY(30);
 		
-		//下部　キャンセルと登録
+		//下部　キャンセルと決定
 		HBox hb_bottom = new HBox();
 		hb_bottom.getChildren().addAll(button);
 		hb_bottom.setPadding(new Insets(9, 9, 9, 9));
@@ -170,37 +208,72 @@ public class SceneSettingClothing extends SceneMain {
 		//データ処理部より服装データを取得するメソッドを呼び出す
 		//List<Clothes> clothes = new DataSettingClothing().getClothes();
 		
-		ObservableList<String> ol =
-				FXCollections.observableArrayList();
-		//すべての服装データをDBからとってくる
+		//閲覧可能リストのオブジェクト生成
+		ol = FXCollections.observableArrayList();
+		
+		//すべての服装データをDBから取得する処理
 		List<Clothes> clothes = new DataSettingClothing().getClothes();
-		//for(int i = 0; i < clothes.size(); i++)
-		//{
-		//	ol.add(clothes.get(i).name);  //Labelに服装名称を追加する
-		//}
 		for(int i = 0; i < clothes.size(); ++i)
 		{
 			ol.add(clothes.get(i).name);
 		}
 	
+		//リストビューに項目を入れる処理
 		lv.setItems(ol);	
 		
+		//イベント割り当て処理
 		event.clickCancel(button.get(0));
 		event.clickAddition(addition);
-		event.clickRegister2(button.get(1),  ol,  lv);
+		event.clickRegister2(button.get(1));
 		
-		//ペイン割り当て
+		//ペイン割り当て処理
 		bp.setTop(vb_top);
 		bp.setCenter(lv);
 		bp.setRight(addition);
 		bp.setBottom(hb_bottom);
-
-		//event.clickRegister2(register, ol, lv);
+		
+		//シーン作成処理
 		this.scene = new Scene(bp, Constant.WIDTH, Constant.HEIGHT);
 	}
-
+	 
+	//-------------------------------------------- 
+	//Scene getScene()
+	//シーン情報を返すメソッド
+	//画面遷移に利用する
+	//scene:シーンのレイアウト情報
+	//--------------------------------------------
 	Scene getScene() 
 	{
 		return this.scene;
+	}
+	
+	//-------------------------------------------- 
+	//ObservableList getOList()
+	//閲覧可能リスト"ol"を返すメソッド
+	//--------------------------------------------
+	ObservableList getOList()
+	{
+		return ol;
+	}
+	
+	//-------------------------------------------- 
+	//ListView getVList()
+	//リストビュー"lv"を返すメソッド
+	//--------------------------------------------
+	ListView getVList()
+	{
+		return lv;
+	}
+	
+	//-------------------------------------------- 
+	//void resetText()
+	//テキストフィールドを空にするメソッド
+	//--------------------------------------------
+	void resetText()
+	{
+		for(int i = 0; i < tf.size(); ++i)
+		{
+			tf.get(i).setText(null);
+		}
 	}
 }


### PR DESCRIPTION
変更点
服装情報設定処理部
・Data処理部に削除メソッドを追加、Event処理部にて呼び出し完了->問題なく動作した
・追加モードにてテキストフィールドに予期せぬ入力がされたとき(服装指数が文字)try-catch処理でエラーアラート表示済み
・削除モードにて何もリストビューが選択されていないまま登録が押されたときtry-catch処理でエラーアラート表示済

未設定未確認
フィードバック処理部
・エラー処理(途中でキャンセルを押した場合は途中までの部分も登録されずになっているか)
・ラジオボタンは最初から1つ選択されているか(されていなければエラー処理)
・登録1回を押すたびにラベルの赤表示を1つずつずらす処理(どこのフィードバックをしているかわかるように)

服装情報設定処理部
・服装追加時に部位名称はある程度絞る必要があるのではないか(現状なんでも入力可能になっている)
　場合によってはここは選択制に変更?
・服装追加時に服装名称、服装分類はなんでも入力可だがこれでよいか